### PR TITLE
Here's the revised message:

### DIFF
--- a/realm_core/src/api.rs
+++ b/realm_core/src/api.rs
@@ -1,4 +1,4 @@
-use actix_web::{get, web, App, HttpResponse, HttpServer, Responder};
+use actix_web::{get, web, HttpResponse, Responder}; // Removed App, HttpServer
 use crate::monitor::{ConnectionMetrics, TCP_CONNECTION_METRICS, UDP_ASSOCIATION_METRICS}; // Adjusted path
 use serde::Serialize;
 use std::net::SocketAddr;

--- a/realm_core/src/monitor.rs
+++ b/realm_core/src/monitor.rs
@@ -3,8 +3,8 @@ use once_cell::sync::Lazy;
 use std::net::SocketAddr;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
-use uuid::Uuid;
-use serde::Serialize;
+// use uuid::Uuid; // Removed as it's not used at the top-level of this file
+use serde::Serialize; // Serialize is used by TrafficStats
 
 pub static TCP_CONNECTION_METRICS: Lazy<DashMap<String, Arc<Mutex<ConnectionMetrics>>>> = Lazy::new(DashMap::new);
 pub static UDP_ASSOCIATION_METRICS: Lazy<DashMap<SocketAddr, Arc<Mutex<ConnectionMetrics>>>> = Lazy::new(DashMap::new);
@@ -15,9 +15,9 @@ pub struct TrafficStats {
     pub rx_bytes: u64,
 }
 
-#[derive(Debug, Serialize, Clone)]
+#[derive(Debug, Clone)] // Removed Serialize
 pub struct ConnectionMetrics {
-    pub traffic: TrafficStats,
+    pub traffic: TrafficStats, // TrafficStats still derives Serialize
     pub start_time: Instant,
     pub last_tx_bytes: u64, // Made public for Serialize and Clone
     pub last_rx_bytes: u64, // Made public for Serialize and Clone

--- a/realm_core/src/udp/batched.rs
+++ b/realm_core/src/udp/batched.rs
@@ -61,6 +61,12 @@ pub struct PacketRef<'buf, 'addr> {
     addr: &'addr SockAddrStore,
 }
 
+impl<'buf, 'addr> PacketRef<'buf, 'addr> {
+    pub fn len(&self) -> usize {
+        self.buf.len()
+    }
+}
+
 impl Packet {
     pub const fn new() -> Self {
         Self {

--- a/realm_core/src/udp/middle.rs
+++ b/realm_core/src/udp/middle.rs
@@ -146,7 +146,7 @@ pub async fn associate_and_relay(
 
             // Uplink traffic processing
             let packets_to_send_iter_vec: Vec<_> = pkts.iter().map(|x| x.ref_with_addr(&raddr.into())).collect();
-            let total_bytes_uplink: usize = packets_to_send_iter_vec.iter().map(|p_ref| p_ref.buf.len()).sum();
+            let total_bytes_uplink: usize = packets_to_send_iter_vec.iter().map(|p_ref| p_ref.len()).sum();
 
             batched::send_all(&rsock, packets_to_send_iter_vec.into_iter()).await?;
 
@@ -192,7 +192,7 @@ async fn send_back(
         };
 
         let packets_to_send_iter_vec: Vec<_> = registry.iter().map(|pkt| pkt.ref_with_addr(&laddr_s)).collect();
-        let total_bytes_downlink: usize = packets_to_send_iter_vec.iter().map(|p_ref| p_ref.buf.len()).sum();
+        let total_bytes_downlink: usize = packets_to_send_iter_vec.iter().map(|p_ref| p_ref.len()).sum();
 
         if let Err(e) = batched::send_all(&lsock, packets_to_send_iter_vec.into_iter()).await {
             log::error!("[udp]failed to sendto client{}: {}", &laddr, e);


### PR DESCRIPTION
Re-submit: Apply compilation fixes for traffic monitoring API

This includes fixes for previously identified compilation errors:
- Removed unused imports in monitor.rs and api.rs.
- Made PacketRef.buf access public via a .len() method in udp/batched.rs and updated udp/middle.rs to use it.
- Removed Serialize derive from ConnectionMetrics in monitor.rs to resolve Instant serialization issues.

These changes aim to ensure the traffic-monitoring-api feature compiles successfully.